### PR TITLE
add `PistonType` field to piston base blocks

### DIFF
--- a/src/main/java/ca/fxco/configurablepistons/base/ModBlocks.java
+++ b/src/main/java/ca/fxco/configurablepistons/base/ModBlocks.java
@@ -88,36 +88,36 @@ public class ModBlocks {
     // Acts exactly like a normal vanilla piston
     public static final BasicPistonHeadBlock BASIC_PISTON_HEAD = registerPiston(BASIC, new BasicPistonHeadBlock());
     public static final BasicMovingBlock BASIC_MOVING_BLOCK = registerPiston(BASIC, new BasicMovingBlock());
-    public static final BasicPistonBaseBlock BASIC_PISTON = registerPiston(BASIC, new BasicPistonBaseBlock(false));
-    public static final BasicPistonBaseBlock BASIC_STICKY_PISTON = registerPiston(BASIC, new BasicPistonBaseBlock(true));
+    public static final BasicPistonBaseBlock BASIC_PISTON = registerPiston(BASIC, new BasicPistonBaseBlock(PistonType.DEFAULT));
+    public static final BasicPistonBaseBlock BASIC_STICKY_PISTON = registerPiston(BASIC, new BasicPistonBaseBlock(PistonType.STICKY));
 
     // Basic Long Piston
     // Can extend further than 1 block
     public static final LongPistonHeadBlock LONG_PISTON_HEAD = registerPiston(LONG, new LongPistonHeadBlock());
     public static final LongMovingBlock LONG_MOVING_BLOCK = registerPiston(LONG, new LongMovingBlock());
-    public static final LongPistonBaseBlock LONG_PISTON = registerPiston(LONG, new LongPistonBaseBlock(false), null);
-    public static final LongPistonBaseBlock LONG_STICKY_PISTON = registerPiston(LONG, new LongPistonBaseBlock(true), null);
+    public static final LongPistonBaseBlock LONG_PISTON = registerPiston(LONG, new LongPistonBaseBlock(PistonType.DEFAULT), null);
+    public static final LongPistonBaseBlock LONG_STICKY_PISTON = registerPiston(LONG, new LongPistonBaseBlock(PistonType.STICKY), null);
     public static final LongPistonArmBlock LONG_PISTON_ARM = registerPiston(LONG, new LongPistonArmBlock());
 
     // Stale Piston
     // A vanilla piston except it cannot be quasi-powered
     public static final BasicPistonHeadBlock STALE_PISTON_HEAD = registerPiston(STALE, new BasicPistonHeadBlock());
-    public static final BasicPistonBaseBlock STALE_PISTON = registerPiston(STALE, new StalePistonBaseBlock(false));
-    public static final BasicPistonBaseBlock STALE_STICKY_PISTON = registerPiston(STALE, new StalePistonBaseBlock(true));
+    public static final BasicPistonBaseBlock STALE_PISTON = registerPiston(STALE, new StalePistonBaseBlock(PistonType.DEFAULT));
+    public static final BasicPistonBaseBlock STALE_STICKY_PISTON = registerPiston(STALE, new StalePistonBaseBlock(PistonType.STICKY));
 
     // Strong Piston
     // Can push 24 blocks, although it takes a lot longer to push (0.05x slower)
     public static final BasicPistonHeadBlock STRONG_PISTON_HEAD = registerPiston(STRONG, new BasicPistonHeadBlock());
     public static final SpeedMovingBlock STRONG_MOVING_BLOCK = registerPiston(STRONG, new SpeedMovingBlock(0.05F));
-    public static final BasicPistonBaseBlock STRONG_PISTON = registerPiston(STRONG, new PushLimitPistonBaseBlock(false,24));
-    public static final BasicPistonBaseBlock STRONG_STICKY_PISTON = registerPiston(STRONG, new PushLimitPistonBaseBlock(true,24));
+    public static final BasicPistonBaseBlock STRONG_PISTON = registerPiston(STRONG, new PushLimitPistonBaseBlock(PistonType.DEFAULT, 24));
+    public static final BasicPistonBaseBlock STRONG_STICKY_PISTON = registerPiston(STRONG, new PushLimitPistonBaseBlock(PistonType.STICKY, 24));
 
     // Fast Piston
     // Can only push 2 block, although it's very fast
     public static final BasicPistonHeadBlock FAST_PISTON_HEAD = registerPiston(FAST, new BasicPistonHeadBlock());
     public static final FastMovingBlock FAST_MOVING_BLOCK = registerPiston(FAST, new FastMovingBlock());
-    public static final BasicPistonBaseBlock FAST_PISTON = registerPiston(FAST, new PushLimitPistonBaseBlock(false,8));
-    public static final BasicPistonBaseBlock FAST_STICKY_PISTON = registerPiston(FAST, new PushLimitPistonBaseBlock(true,8));
+    public static final BasicPistonBaseBlock FAST_PISTON = registerPiston(FAST, new PushLimitPistonBaseBlock(PistonType.DEFAULT, 8));
+    public static final BasicPistonBaseBlock FAST_STICKY_PISTON = registerPiston(FAST, new PushLimitPistonBaseBlock(PistonType.STICKY, 8));
 
     // Very Sticky Piston
     // It's face acts like a slime block, it can be pulled while extended.
@@ -130,29 +130,29 @@ public class ModBlocks {
     // Front Powered Piston
     // Normal piston but can be powered through the front
     public static final BasicPistonHeadBlock FRONT_POWERED_PISTON_HEAD = registerPiston(FRONT_POWERED, new BasicPistonHeadBlock());
-    public static final BasicPistonBaseBlock FRONT_POWERED_PISTON = registerPiston(FRONT_POWERED, new FrontPoweredPistonBaseBlock(false));
-    public static final BasicPistonBaseBlock FRONT_POWERED_STICKY_PISTON = registerPiston(FRONT_POWERED, new FrontPoweredPistonBaseBlock(true));
+    public static final BasicPistonBaseBlock FRONT_POWERED_PISTON = registerPiston(FRONT_POWERED, new FrontPoweredPistonBaseBlock(PistonType.DEFAULT));
+    public static final BasicPistonBaseBlock FRONT_POWERED_STICKY_PISTON = registerPiston(FRONT_POWERED, new FrontPoweredPistonBaseBlock(PistonType.STICKY));
 
 
     // Translocation Piston
     // Normal piston but has 1.10 translocation
     public static final BasicPistonHeadBlock TRANSLOCATION_PISTON_HEAD = registerPiston(TRANSLOCATION, new BasicPistonHeadBlock());
     public static final TranslocationMovingBlock TRANSLOCATION_MOVING_BLOCK = registerPiston(TRANSLOCATION, new TranslocationMovingBlock());
-    public static final BasicPistonBaseBlock TRANSLOCATION_PISTON = registerPiston(TRANSLOCATION, new BasicPistonBaseBlock(false));
-    public static final BasicPistonBaseBlock TRANSLOCATION_STICKY_PISTON = registerPiston(TRANSLOCATION, new BasicPistonBaseBlock(true));
+    public static final BasicPistonBaseBlock TRANSLOCATION_PISTON = registerPiston(TRANSLOCATION, new BasicPistonBaseBlock(PistonType.DEFAULT));
+    public static final BasicPistonBaseBlock TRANSLOCATION_STICKY_PISTON = registerPiston(TRANSLOCATION, new BasicPistonBaseBlock(PistonType.STICKY));
 
     // Slippery Piston
     // It's just a normal piston except its slippery
     public static final BasicPistonHeadBlock SLIPPERY_PISTON_HEAD = registerPiston(SLIPPERY, new SlipperyPistonHeadBlock());
     public static final SlipperyMovingBlock SLIPPERY_MOVING_BLOCK = registerPiston(SLIPPERY, new SlipperyMovingBlock());
-    public static final BasicPistonBaseBlock SLIPPERY_PISTON = registerPiston(SLIPPERY, new SlipperyPistonBaseBlock(false));
-    public static final BasicPistonBaseBlock SLIPPERY_STICKY_PISTON = registerPiston(SLIPPERY, new SlipperyPistonBaseBlock(true));
+    public static final BasicPistonBaseBlock SLIPPERY_PISTON = registerPiston(SLIPPERY, new SlipperyPistonBaseBlock(PistonType.DEFAULT));
+    public static final BasicPistonBaseBlock SLIPPERY_STICKY_PISTON = registerPiston(SLIPPERY, new SlipperyPistonBaseBlock(PistonType.STICKY));
 
     // Super Piston
     // What's push limit? What is super sticky?
     public static final BasicPistonHeadBlock SUPER_PISTON_HEAD = registerPiston(SUPER, new BasicPistonHeadBlock());
-    public static final BasicPistonBaseBlock SUPER_PISTON = registerPiston(SUPER, new PushLimitPistonBaseBlock(false, Integer.MAX_VALUE));
-    public static final BasicPistonBaseBlock SUPER_STICKY_PISTON = registerPiston(SUPER, new PushLimitPistonBaseBlock(true, Integer.MAX_VALUE));
+    public static final BasicPistonBaseBlock SUPER_PISTON = registerPiston(SUPER, new PushLimitPistonBaseBlock(PistonType.DEFAULT, Integer.MAX_VALUE));
+    public static final BasicPistonBaseBlock SUPER_STICKY_PISTON = registerPiston(SUPER, new PushLimitPistonBaseBlock(PistonType.STICKY, Integer.MAX_VALUE));
 
     //
     // Registration methods
@@ -185,8 +185,8 @@ public class ModBlocks {
                 family.head(headBlock);
             } else {
                 throw new IllegalStateException(
-                        "First Piston Family block must be a basic piston head block! - Block: " +
-                                block + " - Family: " + family.getId()
+                    "First Piston Family block must be a basic piston head block! - Block: " +
+                        block + " - Family: " + family.getId()
                 );
             }
         } else {
@@ -195,24 +195,21 @@ public class ModBlocks {
                 baseBlock.setMovingBlock(movingBlock != null ? movingBlock : BASIC_MOVING_BLOCK);
                 BasicPistonHeadBlock headBlock = family.getHeadBlock();
                 baseBlock.setHeadBlock(headBlock != null ? headBlock : ModBlocks.BASIC_PISTON_HEAD);
-                ResourceLocation id;
-                if (baseBlock.isSticky) {
-                    id = id(familyId + "_sticky_piston");
-                    Registry.register(BuiltInRegistries.BLOCK, id, baseBlock);
-                    family.base(PistonType.STICKY, baseBlock);
-                } else {
-                    id = id(familyId + "_piston");
-                    Registry.register(BuiltInRegistries.BLOCK, id, baseBlock);
-                    family.base(PistonType.DEFAULT, baseBlock);
-                }
+                ResourceLocation id = switch (baseBlock.type) {
+                    case DEFAULT -> id(familyId + "_piston");
+                    case STICKY -> id(familyId + "_sticky_piston");
+                    default -> throw new IllegalStateException("unknown base type " + baseBlock.type);
+                };
+                Registry.register(BuiltInRegistries.BLOCK, id, baseBlock);
+                family.base(baseBlock);
                 if (creativeModeTab != null) {
                     Registry.register(BuiltInRegistries.ITEM, id, new BlockItem(baseBlock, new Item.Properties()));
                 }
             } else if (block instanceof BasicMovingBlock movingBlock) {
                 Registry.register(BuiltInRegistries.BLOCK, id(familyId + "_moving_piston"), movingBlock);
-                if (family.getBaseBlock(PistonType.DEFAULT) != null || family.getBaseBlock(PistonType.STICKY) != null) {
+                if (family.getBaseBlock() != null) {
                     throw new IllegalStateException(
-                        "Extension blocks must always be initialized before base piston blocks! - Block: " +
+                        "Moving blocks must always be initialized before base blocks! - Block: " +
                             BuiltInRegistries.BLOCK.getId(movingBlock) + " - Family: " + family.getId()
                     );
                 }

--- a/src/main/java/ca/fxco/configurablepistons/blocks/pistons/FrontPoweredPistonBaseBlock.java
+++ b/src/main/java/ca/fxco/configurablepistons/blocks/pistons/FrontPoweredPistonBaseBlock.java
@@ -5,11 +5,12 @@ import ca.fxco.configurablepistons.blocks.pistons.basePiston.BasicPistonBaseBloc
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.properties.PistonType;
 
 public class FrontPoweredPistonBaseBlock extends BasicPistonBaseBlock {
 
-	public FrontPoweredPistonBaseBlock(boolean sticky) {
-        super(sticky);
+	public FrontPoweredPistonBaseBlock(PistonType type) {
+        super(type);
     }
 
     @Override

--- a/src/main/java/ca/fxco/configurablepistons/blocks/pistons/PushLimitPistonBaseBlock.java
+++ b/src/main/java/ca/fxco/configurablepistons/blocks/pistons/PushLimitPistonBaseBlock.java
@@ -6,13 +6,15 @@ import ca.fxco.configurablepistons.pistonLogic.pistonHandlers.ConfigurablePiston
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.properties.PistonType;
 
 public class PushLimitPistonBaseBlock extends BasicPistonBaseBlock {
 
     protected final int pushLimit;
 
-    public PushLimitPistonBaseBlock(boolean isSticky, int pushLimit) {
-        super(isSticky);
+    public PushLimitPistonBaseBlock(PistonType type, int pushLimit) {
+        super(type);
+
         this.pushLimit = pushLimit;
     }
 

--- a/src/main/java/ca/fxco/configurablepistons/blocks/pistons/StalePistonBaseBlock.java
+++ b/src/main/java/ca/fxco/configurablepistons/blocks/pistons/StalePistonBaseBlock.java
@@ -6,11 +6,12 @@ import ca.fxco.configurablepistons.helpers.Utils;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.properties.PistonType;
 
 public class StalePistonBaseBlock extends BasicPistonBaseBlock {
 
-    public StalePistonBaseBlock(boolean isSticky) {
-        super(isSticky);
+    public StalePistonBaseBlock(PistonType type) {
+        super(type);
     }
 
     @Override

--- a/src/main/java/ca/fxco/configurablepistons/blocks/pistons/basePiston/BasicPistonBaseBlock.java
+++ b/src/main/java/ca/fxco/configurablepistons/blocks/pistons/basePiston/BasicPistonBaseBlock.java
@@ -1,5 +1,7 @@
 package ca.fxco.configurablepistons.blocks.pistons.basePiston;
 
+import java.util.Objects;
+
 import ca.fxco.configurablepistons.base.ModBlocks;
 import ca.fxco.configurablepistons.base.ModTags;
 import ca.fxco.configurablepistons.helpers.Utils;
@@ -49,27 +51,27 @@ public class BasicPistonBaseBlock extends DirectionalBlock {
     protected static final VoxelShape EXTENDED_UP_SHAPE = Block.box(0.0, 0.0, 0.0, 16.0, 12.0, 16.0);
     protected static final VoxelShape EXTENDED_DOWN_SHAPE = Block.box(0.0, 4.0, 0.0, 16.0, 16.0, 16.0);
 
-    public final boolean isSticky;
+    public final PistonType type;
 
     protected BasicMovingBlock MOVING_BLOCK;
     protected BasicPistonHeadBlock HEAD_BLOCK;
 
-    public BasicPistonBaseBlock(boolean isSticky) {
-        this(isSticky, ModBlocks.BASIC_MOVING_BLOCK, ModBlocks.BASIC_PISTON_HEAD);
+    public BasicPistonBaseBlock(PistonType type) {
+        this(type, ModBlocks.BASIC_MOVING_BLOCK, ModBlocks.BASIC_PISTON_HEAD);
     }
 
-    public BasicPistonBaseBlock(boolean isSticky, Properties properties) {
-        this(isSticky, properties, ModBlocks.BASIC_MOVING_BLOCK, ModBlocks.BASIC_PISTON_HEAD);
+    public BasicPistonBaseBlock(PistonType type, Properties properties) {
+        this(type, properties, ModBlocks.BASIC_MOVING_BLOCK, ModBlocks.BASIC_PISTON_HEAD);
     }
 
-    public BasicPistonBaseBlock(boolean isSticky, BasicMovingBlock movingBlock, BasicPistonHeadBlock headBlock) {
-        this(isSticky, FabricBlockSettings.copyOf(Blocks.PISTON), movingBlock, headBlock);
+    public BasicPistonBaseBlock(PistonType type, BasicMovingBlock movingBlock, BasicPistonHeadBlock headBlock) {
+        this(type, FabricBlockSettings.copyOf(Blocks.PISTON), movingBlock, headBlock);
     }
 
-    public BasicPistonBaseBlock(boolean isSticky, Properties properties, BasicMovingBlock movingBlock, BasicPistonHeadBlock headBlock) {
+    public BasicPistonBaseBlock(PistonType type, Properties properties, BasicMovingBlock movingBlock, BasicPistonHeadBlock headBlock) {
         super(properties);
 
-        this.isSticky = isSticky;
+        this.type = Objects.requireNonNull(type);
 
         MOVING_BLOCK = movingBlock;
         HEAD_BLOCK = headBlock;
@@ -211,7 +213,7 @@ public class BasicPistonBaseBlock extends DirectionalBlock {
 
             BlockState movingBaseState = MOVING_BLOCK.defaultBlockState()
                 .setValue(MovingPistonBlock.FACING, facing)
-                .setValue(MovingPistonBlock.TYPE, this.isSticky ? PistonType.STICKY : PistonType.DEFAULT);
+                .setValue(MovingPistonBlock.TYPE, this.type);
             BlockEntity movingBaseBlockEntity = MOVING_BLOCK.createMovingBlockEntity(
                 pos,
                 movingBaseState,
@@ -227,7 +229,7 @@ public class BasicPistonBaseBlock extends DirectionalBlock {
             world.updateNeighborsAt(pos, movingBaseState.getBlock());
             movingBaseState.updateNeighbourShapes(world, pos, UPDATE_CLIENTS);
 
-            if (this.isSticky) {
+            if (this.type == PistonType.STICKY) {
                 boolean droppedBlock = false;
 
                 BlockPos frontPos = pos.relative(facing, 2);

--- a/src/main/java/ca/fxco/configurablepistons/blocks/pistons/longPiston/LongPistonBaseBlock.java
+++ b/src/main/java/ca/fxco/configurablepistons/blocks/pistons/longPiston/LongPistonBaseBlock.java
@@ -1,8 +1,8 @@
 package ca.fxco.configurablepistons.blocks.pistons.longPiston;
 
 import ca.fxco.configurablepistons.base.ModBlocks;
-import ca.fxco.configurablepistons.blocks.pistons.basePiston.BasicPistonBaseBlock;
 import ca.fxco.configurablepistons.blocks.pistons.basePiston.BasicMovingBlock;
+import ca.fxco.configurablepistons.blocks.pistons.basePiston.BasicPistonBaseBlock;
 import ca.fxco.configurablepistons.blocks.pistons.basePiston.BasicPistonHeadBlock;
 import ca.fxco.configurablepistons.pistonLogic.pistonHandlers.ConfigurableLongPistonHandler;
 import ca.fxco.configurablepistons.pistonLogic.pistonHandlers.ConfigurablePistonStructureResolver;
@@ -13,24 +13,25 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.properties.PistonType;
 
 public class LongPistonBaseBlock extends BasicPistonBaseBlock {
 
-    public LongPistonBaseBlock(boolean isSticky) {
-        this(isSticky, ModBlocks.LONG_MOVING_BLOCK, ModBlocks.LONG_PISTON_HEAD);
+    public LongPistonBaseBlock(PistonType type) {
+        this(type, ModBlocks.LONG_MOVING_BLOCK, ModBlocks.LONG_PISTON_HEAD);
     }
 
-    public LongPistonBaseBlock(boolean isSticky, Properties properties) {
-        this(isSticky, properties, ModBlocks.LONG_MOVING_BLOCK, ModBlocks.LONG_PISTON_HEAD);
+    public LongPistonBaseBlock(PistonType type, Properties properties) {
+        this(type, properties, ModBlocks.LONG_MOVING_BLOCK, ModBlocks.LONG_PISTON_HEAD);
     }
 
-    public LongPistonBaseBlock(boolean isSticky, LongMovingBlock movingBlock, LongPistonHeadBlock headBlock) {
-        this(isSticky, FabricBlockSettings.copyOf(Blocks.PISTON), movingBlock, headBlock);
+    public LongPistonBaseBlock(PistonType type, LongMovingBlock movingBlock, LongPistonHeadBlock headBlock) {
+        this(type, FabricBlockSettings.copyOf(Blocks.PISTON), movingBlock, headBlock);
     }
 
-    public LongPistonBaseBlock(boolean isSticky, Properties properties,
+    public LongPistonBaseBlock(PistonType type, Properties properties,
                             LongMovingBlock movingBlock, LongPistonHeadBlock headBlock) {
-        super(isSticky, properties, movingBlock, headBlock);
+        super(type, properties, movingBlock, headBlock);
     }
 
     @Override

--- a/src/main/java/ca/fxco/configurablepistons/blocks/pistons/slipperyPiston/SlipperyPistonBaseBlock.java
+++ b/src/main/java/ca/fxco/configurablepistons/blocks/pistons/slipperyPiston/SlipperyPistonBaseBlock.java
@@ -12,14 +12,15 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.PistonType;
 
 import static ca.fxco.configurablepistons.blocks.slipperyBlocks.BaseSlipperyBlock.MAX_DISTANCE;
 import static ca.fxco.configurablepistons.blocks.slipperyBlocks.BaseSlipperyBlock.SLIPPERY_DELAY;
 
 public class SlipperyPistonBaseBlock extends BasicPistonBaseBlock {
 
-    public SlipperyPistonBaseBlock(boolean isSticky) {
-        super(isSticky);
+    public SlipperyPistonBaseBlock(PistonType type) {
+        super(type);
     }
 
     @Override

--- a/src/main/java/ca/fxco/configurablepistons/blocks/pistons/veryStickyPiston/VeryStickyPistonBaseBlock.java
+++ b/src/main/java/ca/fxco/configurablepistons/blocks/pistons/veryStickyPiston/VeryStickyPistonBaseBlock.java
@@ -12,11 +12,12 @@ import net.minecraft.core.Direction;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.PistonType;
 
 public class VeryStickyPistonBaseBlock extends BasicPistonBaseBlock implements ConfigurablePistonBehavior, ConfigurablePistonStickiness {
 
     public VeryStickyPistonBaseBlock() {
-        super(true);
+        super(PistonType.STICKY);
     }
 
     // I want to create a diagonal block entity instead of just teleporting blocks

--- a/src/main/java/ca/fxco/configurablepistons/pistonLogic/PistonUtils.java
+++ b/src/main/java/ca/fxco/configurablepistons/pistonLogic/PistonUtils.java
@@ -107,11 +107,11 @@ public class PistonUtils {
             blockStates[j++] = state2;
         }
         if (push) {
-            PistonType pistonType = piston.isSticky ? PistonType.STICKY : PistonType.DEFAULT;
+            PistonType pistonType = piston.type;
             BlockState state4 = piston.getHeadBlock().defaultBlockState().setValue(PistonHeadBlock.FACING, dir)
                     .setValue(PistonHeadBlock.TYPE, pistonType);
             state2 = piston.getMovingBlock().defaultBlockState().setValue(MovingPistonBlock.FACING, dir)
-                    .setValue(MovingPistonBlock.TYPE, piston.isSticky ? PistonType.STICKY : PistonType.DEFAULT);
+                    .setValue(MovingPistonBlock.TYPE, piston.type);
             map.remove(pos2);
             world.setBlock(pos2, state2, Block.UPDATE_IMMEDIATE | Block.UPDATE_MOVE_BY_PISTON);
             world.setBlockEntity(piston.getMovingBlock().createMovingBlockEntity(

--- a/src/main/java/ca/fxco/configurablepistons/pistonLogic/families/PistonFamily.java
+++ b/src/main/java/ca/fxco/configurablepistons/pistonLogic/families/PistonFamily.java
@@ -1,7 +1,5 @@
 package ca.fxco.configurablepistons.pistonLogic.families;
 
-import java.util.Objects;
-
 import org.jetbrains.annotations.Nullable;
 
 import ca.fxco.configurablepistons.blocks.pistons.basePiston.BasicPistonBaseBlock;
@@ -49,15 +47,23 @@ public class PistonFamily {
     }
 
     public @Nullable BasicPistonBaseBlock getBaseBlock(PistonType type) {
-        return getBaseBlock(Objects.requireNonNull(type) == PistonType.STICKY);
-    }
-
-    public @Nullable BasicPistonBaseBlock getBaseBlock(boolean sticky) {
-        return sticky ? this.stickyBaseBlock : this.normalBaseBlock;
+        return switch (type) {
+            case DEFAULT -> normalBaseBlock;
+            case STICKY -> stickyBaseBlock;
+            default -> throw new IllegalArgumentException("unknown base type " + type);
+        };
     }
 
     public Block getBaseBlock() {
-        return this.normalBaseBlock == null ? this.stickyBaseBlock : this.normalBaseBlock;
+        for (PistonType type : PistonType.values()) {
+            Block baseBlock = getBaseBlock(type);
+
+            if (baseBlock != null) {
+                return baseBlock;
+            }
+        }
+
+        return null;
     }
 
     public @Nullable BasicMovingBlock getMovingBlock() {
@@ -91,16 +97,17 @@ public class PistonFamily {
 
     public void head(BasicPistonHeadBlock block) {
         this.headBlock = block;
-        PistonFamilies.registerPistonHead(block,this); // Adds the piston head to the quick lookup table
+        PistonFamilies.registerPistonHead(block, this); // Adds the piston head to the quick lookup table
     }
 
-    public void base(PistonType type, BasicPistonBaseBlock block) {
-        Objects.requireNonNull(type);
-        if (type == PistonType.STICKY) {
-            this.stickyBaseBlock = block;
-        } else {
-            this.normalBaseBlock = block;
-        }
+    public void base(BasicPistonBaseBlock block) {
+        if (getBaseBlock(block.type) != null)
+            throw new IllegalStateException("base of type " + block.type + " has already been registered!");
+        switch (block.type) {
+            case DEFAULT -> normalBaseBlock = block;
+            case STICKY -> stickyBaseBlock = block;
+            default -> throw new IllegalArgumentException("unknown base type " + block.type);
+        };
     }
 
     public void moving(BasicMovingBlock block) {

--- a/src/main/java/ca/fxco/configurablepistons/renderers/BasicPistonBlockEntityRenderer.java
+++ b/src/main/java/ca/fxco/configurablepistons/renderers/BasicPistonBlockEntityRenderer.java
@@ -85,7 +85,7 @@ public class BasicPistonBlockEntityRenderer<T extends BasicMovingBlockEntity> im
             }
         } else {
             if (state.getBlock() instanceof BasicPistonBaseBlock base) {
-                PistonType type = base.isSticky ? PistonType.STICKY : PistonType.DEFAULT;
+                PistonType type = base.type;
                 Direction facing = state.getValue(BasicPistonBaseBlock.FACING);
 
                 BlockState headState = base.getHeadBlock().defaultBlockState()

--- a/src/main/java/ca/fxco/configurablepistons/renderers/LongPistonBlockEntityRenderer.java
+++ b/src/main/java/ca/fxco/configurablepistons/renderers/LongPistonBlockEntityRenderer.java
@@ -37,7 +37,7 @@ public class LongPistonBlockEntityRenderer<T extends LongMovingBlockEntity> exte
             }
         } else {
             if (state.getBlock() instanceof BasicPistonBaseBlock base) {
-                PistonType type = base.isSticky ? PistonType.STICKY : PistonType.DEFAULT;
+                PistonType type = base.type;
                 Direction facing = state.getValue(BasicPistonBaseBlock.FACING);
 
                 BlockState renderState;


### PR DESCRIPTION
This field replaces the `isSticky` boolean field that Vanilla piston base blocks use. 