### PR TITLE
StructureRunner Rewrite

### DIFF
--- a/src/main/java/ca/fxco/pistonlib/blocks/pistons/basePiston/BasicPistonBaseBlock.java
+++ b/src/main/java/ca/fxco/pistonlib/blocks/pistons/basePiston/BasicPistonBaseBlock.java
@@ -123,10 +123,11 @@ public class BasicPistonBaseBlock extends DirectionalBlock {
                 new BasicStructureResolver(this, level, pos, facing, extend);
     }
 
-    public StructureRunner newStructureRunner() {
+    public StructureRunner newStructureRunner(Level level, BlockPos pos, Direction facing, boolean extend,
+                                              BasicStructureResolver.Factory<? extends BasicStructureResolver> structureProvider) {
         return PistonLibConfig.mergingApi ?
-                new MergingStructureRunner(this.family, this.type) :
-                new BasicStructureRunner(this.family, this.type);
+                new MergingStructureRunner(level, pos, facing, this.family, this.type, extend , structureProvider) :
+                new BasicStructureRunner(level, pos, facing, this.family, this.type, extend , structureProvider);
     }
 
     public void checkIfExtend(Level level, BlockPos pos, BlockState state) {
@@ -365,7 +366,7 @@ public class BasicPistonBaseBlock extends DirectionalBlock {
     }
 
     public boolean moveBlocks(Level level, BlockPos pos, Direction facing, boolean extend) {
-        StructureRunner structureRunner = newStructureRunner();
-        return structureRunner.run(level, pos, facing, extend, this::newStructureResolver);
+        StructureRunner structureRunner = newStructureRunner(level, pos, facing, extend, this::newStructureResolver);
+        return structureRunner.run();
     }
 }

--- a/src/main/java/ca/fxco/pistonlib/mixin/ServerLevel_interactionMixin.java
+++ b/src/main/java/ca/fxco/pistonlib/mixin/ServerLevel_interactionMixin.java
@@ -66,14 +66,14 @@ public abstract class ServerLevel_interactionMixin extends Level implements Serv
         pistonEvents.clear();
         for (PistonEventData pistonEventData : runningPistonEvents) {
             BasicPistonBaseBlock pistonBlock = pistonEventData.pistonBlock();
-            StructureRunner structureRunner = new DecoupledStructureRunner(pistonBlock.newStructureRunner());
-            if (structureRunner.run(
+            StructureRunner structureRunner = new DecoupledStructureRunner(pistonBlock.newStructureRunner(
                     this,
                     pistonEventData.pos(),
                     pistonEventData.dir(),
                     pistonEventData.extend(),
-                    pistonBlock::newStructureResolver)
-            ) {
+                    pistonBlock::newStructureResolver
+            ));
+            if (structureRunner.run()) {
                 PLNetwork.sendToClientsInRange(
                         this.getServer(),
                         GlobalPos.of(this.dimension(), pistonEventData.pos()),

--- a/src/main/java/ca/fxco/pistonlib/network/packets/ClientboundPistonEventPacket.java
+++ b/src/main/java/ca/fxco/pistonlib/network/packets/ClientboundPistonEventPacket.java
@@ -44,7 +44,7 @@ public class ClientboundPistonEventPacket extends PLPacket {
 
     @Override
     public void handleClient(Minecraft client, PacketSender packetSender) {
-        StructureRunner structureRunner = new DecoupledStructureRunner(this.pistonBlock.newStructureRunner());
-        structureRunner.run(client.level, this.pos, this.dir, this.extend, this.pistonBlock::newStructureResolver);
+        StructureRunner structureRunner = new DecoupledStructureRunner(this.pistonBlock.newStructureRunner(client.level, this.pos, this.dir, this.extend, this.pistonBlock::newStructureResolver));
+        structureRunner.run();
     }
 }

--- a/src/main/java/ca/fxco/pistonlib/pistonLogic/structureRunners/DecoupledStructureRunner.java
+++ b/src/main/java/ca/fxco/pistonlib/pistonLogic/structureRunners/DecoupledStructureRunner.java
@@ -1,16 +1,6 @@
 package ca.fxco.pistonlib.pistonLogic.structureRunners;
 
-import ca.fxco.pistonlib.pistonLogic.families.PistonFamily;
-import ca.fxco.pistonlib.pistonLogic.structureResolvers.MergingPistonStructureResolver;
 import lombok.RequiredArgsConstructor;
-import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
-import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.piston.PistonStructureResolver;
-import net.minecraft.world.level.block.state.BlockState;
-
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * A Structure Runner Wrapper that decouples the structure runner from having a physical piston
@@ -22,69 +12,72 @@ public class DecoupledStructureRunner implements StructureRunner {
     private final StructureRunner structureRunner;
 
     @Override
-    public PistonFamily getFamily() {
-        return structureRunner.getFamily();
-    }
-
-    @Override
-    public void taskRemovePistonHeadOnRetract(Level level, BlockPos pos, Direction facing, boolean extend) {
+    public void taskRemovePistonHeadOnRetract() {
         // No piston head to modify!
     }
 
     @Override
-    public void taskSetPositionsToMove(Level level, List<BlockPos> toMove, Direction moveDir) {
-        structureRunner.taskSetPositionsToMove(level, toMove, moveDir);
+    public boolean taskRunStructureResolver() {
+        return structureRunner.taskRunStructureResolver();
     }
 
     @Override
-    public void taskMergeBlocks(Level level, BlockPos pos, Direction facing, boolean extend, MergingPistonStructureResolver structure, Direction moveDir) {
-        structureRunner.taskMergeBlocks(level, pos, facing, extend, structure, moveDir);
+    public void taskSetPositionsToMove() {
+        structureRunner.taskSetPositionsToMove();
     }
 
     @Override
-    public void taskDestroyBlocks(Level level, BlockPos pos, List<BlockPos> toDestroy, BlockState[] affectedStates, AtomicInteger affectedIndex) {
-        structureRunner.taskDestroyBlocks(level, pos, toDestroy, affectedStates, affectedIndex);
+    public void taskMergeBlocks() {
+        structureRunner.taskMergeBlocks();
     }
 
     @Override
-    public void taskPreventTntDuping(Level level, BlockPos pos, List<BlockPos> toMove) {
-        structureRunner.taskPreventTntDuping(level, pos, toMove);
+    public void taskDestroyBlocks() {
+        structureRunner.taskDestroyBlocks();
     }
 
     @Override
-    public void taskMoveBlocks(Level level, BlockPos pos, PistonStructureResolver structure, Direction facing, boolean extend, List<BlockPos> toMove, BlockState[] affectedStates, AtomicInteger affectedIndex, Direction moveDir) {
-        structureRunner.taskMoveBlocks(level, pos, structure, facing, extend, toMove, affectedStates, affectedIndex, moveDir);
+    public void taskPreventTntDuping() {
+        structureRunner.taskPreventTntDuping();
     }
 
     @Override
-    public void taskPlaceExtendingHead(Level level, BlockPos pos, Direction facing, boolean extend) {
+    public void taskMoveBlocks() {
+        structureRunner.taskMoveBlocks();
+    }
+
+    @Override
+    public void taskPlaceExtendingHead() {
         // Don't place a piston head without a piston base!
     }
 
     @Override
-    public void taskRemoveLeftOverBlocks(Level level) {
-        structureRunner.taskRemoveLeftOverBlocks(level);
+    public void taskRemoveLeftOverBlocks() {
+        structureRunner.taskRemoveLeftOverBlocks();
     }
 
     @Override
-    public void taskDoRemoveNeighborUpdates(Level level) {
-        structureRunner.taskDoRemoveNeighborUpdates(level);
+    public void taskDoRemoveNeighborUpdates() {
+        structureRunner.taskDoRemoveNeighborUpdates();
     }
 
     @Override
-    public void taskDoDestroyNeighborUpdates(Level level, List<BlockPos> toMove, List<BlockPos> toDestroy,
-                                             BlockState[] affectedStates, AtomicInteger affectedIndex) {
-        structureRunner.taskDoDestroyNeighborUpdates(level, toDestroy, toMove, affectedStates, affectedIndex);
+    public void taskDoDestroyNeighborUpdates() {
+        structureRunner.taskDoDestroyNeighborUpdates();
     }
 
     @Override
-    public void taskDoMoveNeighborUpdates(Level level, List<BlockPos> toMove, BlockState[] affectedStates,
-                                          AtomicInteger affectedIndex) {
-        structureRunner.taskDoMoveNeighborUpdates(level, toMove, affectedStates, affectedIndex);
+    public void taskDoMoveNeighborUpdates() {
+        structureRunner.taskDoMoveNeighborUpdates();
     }
 
     @Override
-    public void taskDoUnMergeUpdates(Level level) {
-        structureRunner.taskDoUnMergeUpdates(level);
+    public void taskDoUnMergeUpdates() {
+        structureRunner.taskDoUnMergeUpdates();
+    }
+
+    @Override
+    public void taskDoPistonHeadExtendingUpdate() {
+        structureRunner.taskDoPistonHeadExtendingUpdate();
     }
 }

--- a/src/main/java/ca/fxco/pistonlib/pistonLogic/structureRunners/MergingStructureRunner.java
+++ b/src/main/java/ca/fxco/pistonlib/pistonLogic/structureRunners/MergingStructureRunner.java
@@ -8,6 +8,7 @@ import ca.fxco.pistonlib.impl.BlockEntityMerging;
 import ca.fxco.pistonlib.pistonLogic.families.PistonFamily;
 import ca.fxco.pistonlib.pistonLogic.internal.BlockStateBaseMerging;
 import ca.fxco.pistonlib.pistonLogic.structureGroups.StructureGroup;
+import ca.fxco.pistonlib.pistonLogic.structureResolvers.BasicStructureResolver;
 import ca.fxco.pistonlib.pistonLogic.structureResolvers.MergingPistonStructureResolver;
 import com.mojang.datafixers.util.Pair;
 import net.minecraft.core.BlockPos;
@@ -15,30 +16,38 @@ import net.minecraft.core.Direction;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.level.block.piston.PistonStructureResolver;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.PistonType;
 
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static net.minecraft.world.level.block.Block.*;
 import static net.minecraft.world.level.block.Block.UPDATE_INVISIBLE;
 
 public class MergingStructureRunner extends BasicStructureRunner {
 
-    private final Map<BlockPos, BlockState> toKeep = new LinkedHashMap<>();
+    private Map<BlockPos, BlockState> toKeep;
     private BlockState[] unMergingStates;
     private int unMergingIndex = 0;
 
-    public MergingStructureRunner(PistonFamily family, PistonType type) {
-        super(family, type);
+    public MergingStructureRunner(Level level, BlockPos pos, Direction facing, PistonFamily family, PistonType type,
+                                  boolean extend, BasicStructureResolver.Factory<? extends BasicStructureResolver> structureProvider) {
+        super(level, pos, facing, family, type, extend, structureProvider);
     }
 
     @Override
-    public void taskSetPositionsToMove(Level level, List<BlockPos> toMove, Direction moveDir) {
+    public boolean taskRunStructureResolver() {
+        if (!super.taskRunStructureResolver()) {
+            return false;
+        }
+        this.toKeep = new LinkedHashMap<>();
+        return true;
+    }
+
+    @Override
+    public void taskSetPositionsToMove() {
         for (BlockPos posToMove : toMove) {
             BlockState stateToMove = level.getBlockState(posToMove);
             BlockEntity blockEntityToMove = level.getBlockEntity(posToMove);
@@ -57,9 +66,7 @@ public class MergingStructureRunner extends BasicStructureRunner {
     }
 
     @Override
-    public void taskMoveBlocks(Level level, BlockPos pos, PistonStructureResolver structure, Direction facing,
-                               boolean extend, List<BlockPos> toMove, BlockState[] affectedStates,
-                               AtomicInteger affectedIndex, Direction moveDir) {
+    public void taskMoveBlocks() {
         int moveSize = toMove.size();
         if (moveSize > 0) {
             StructureGroup structureGroup = null;
@@ -96,7 +103,7 @@ public class MergingStructureRunner extends BasicStructureRunner {
                             stateToMove = unmergedStates.getFirst();
                             BlockState stateToKeep = unmergedStates.getSecond();
                             toKeep.put(posToMove, stateToKeep);
-                            affectedStates[affectedIndex.getAndIncrement()] = stateToKeep;
+                            affectedStates[affectedIndex++] = stateToKeep;
                             toRemove.remove(posToMove);
                             move = false;
                         }
@@ -114,16 +121,18 @@ public class MergingStructureRunner extends BasicStructureRunner {
                 level.setBlockEntity(movingBlockEntity);
 
                 if (move) {
-                    affectedStates[affectedIndex.getAndIncrement()] = stateToMove;
+                    affectedStates[affectedIndex++] = stateToMove;
                 }
             }
         }
     }
 
     @Override
-    public void taskMergeBlocks(Level level, BlockPos pos, Direction facing, boolean extend,
-                                MergingPistonStructureResolver structure, Direction moveDir) {
-        List<BlockPos> toMerge = structure.getToMerge();
+    public void taskMergeBlocks() {
+        if (!(structure instanceof MergingPistonStructureResolver mergingStructure)) {
+            return;
+        }
+        List<BlockPos> toMerge = mergingStructure.getToMerge();
         float speed = extend ? family.getExtendingSpeed() : family.getRetractingSpeed();
 
         // Merge Blocks
@@ -184,7 +193,7 @@ public class MergingStructureRunner extends BasicStructureRunner {
     }
 
     @Override
-    public void taskDoUnMergeUpdates(Level level) {
+    public void taskDoUnMergeUpdates() {
         int unMergingIndex = 0;
 
         // Keep these blocks as they unmerged, just change there state to the new one


### PR DESCRIPTION
Rewrite StructureRunner to allow for much easier customization and expandability

Before all the structure runner methods had specific parameters based on what code was running in each method.
This limits other mods from inheriting the structure runner and adding custom logic into this methods, since they would only have access to specific values during each task. 
Now, all values are accessible within all tasks.