### PR TITLE
Implement proper caching fixes in structure runner

### DIFF
--- a/src/main/java/ca/fxco/pistonlib/PistonLibConfig.java
+++ b/src/main/java/ca/fxco/pistonlib/PistonLibConfig.java
@@ -116,9 +116,19 @@ public class PistonLibConfig {
 
     @ConfigValue(
             desc = "Fixes tnt duping using pistons",
-            more = "This does also fix some other edge cases with modded blocks that behave the same when powered",
+            more = {"This does also fix some other edge cases with modded blocks that behave the same when powered",
+                    "Requires `pistonPushingCacheFix`"},
             keyword = {"tnt", "duping"},
             category = Category.FIX
     )
     public static boolean tntDupingFix = false;
+
+    @ConfigValue(
+            desc = "Fixes the way piston pushing cache works",
+            more = {"Prevents multiple duping methods based on update order and internal cache",
+                    "Disable this rule in order to have the exact same vanilla duping behaviour"},
+            keyword = {"cache", "duping"},
+            category = Category.FIX
+    )
+    public static boolean pistonPushingCacheFix = true;
 }

--- a/src/main/java/ca/fxco/pistonlib/pistonLogic/structureRunners/BasicStructureRunner.java
+++ b/src/main/java/ca/fxco/pistonlib/pistonLogic/structureRunners/BasicStructureRunner.java
@@ -115,7 +115,7 @@ public class BasicStructureRunner implements StructureRunner {
 
     @Override
     public void taskDestroyBlocks() {
-        this.affectedStates = new BlockState[this.toMove.size() + this.toDestroy.size()];
+        this.affectedStates = new BlockState[toDestroy.size() + toMove.size()];
 
         for (int i = toDestroy.size() - 1; i >= 0; i--) {
             BlockPos posToDestroy = toDestroy.get(i);
@@ -133,7 +133,10 @@ public class BasicStructureRunner implements StructureRunner {
     }
 
     @Override
-    public void taskPreventTntDuping() {
+    public void taskFixUpdatesAndStates() {
+        if (!PistonLibConfig.pistonPushingCacheFix) {
+            return;
+        }
         int moveSize = toMove.size();
         if (moveSize > 0) {
             for (int i = moveSize - 1; i >= 0; i--) {
@@ -142,13 +145,18 @@ public class BasicStructureRunner implements StructureRunner {
                 // Get the current state from the Level
                 BlockState stateToMove = level.getBlockState(posToMove);
 
+                if (!PistonLibConfig.tntDupingFix && (stateToMove.is(Blocks.TNT) || stateToMove.canBeReplaced())) {
+                    continue;
+                }
+
                 // Vanilla usually uses the update flags UPDATE_INVISIBLE & UPDATE_MOVE_BY_PISTON
                 // Here we also add UPDATE_KNOWN_SHAPE, this removes block updates and state updates,
                 // we than also add UPDATE_CLIENTS in order for shapes can be updated correctly about the block being AIR now.
-                level.setBlock(posToMove, Blocks.AIR.defaultBlockState(), UPDATE_CLIENTS | UPDATE_INVISIBLE | UPDATE_KNOWN_SHAPE | UPDATE_MOVE_BY_PISTON);
+                int updateFlags = UPDATE_CLIENTS | UPDATE_INVISIBLE | UPDATE_MOVE_BY_PISTON;
+                level.setBlock(posToMove, Blocks.AIR.defaultBlockState(), PistonLibConfig.tntDupingFix ? updateFlags | UPDATE_KNOWN_SHAPE : updateFlags);
 
                 // We replace the current state in the cached states with the latest version from the world
-                this.statesToMove.set(i, stateToMove);
+                statesToMove.set(i, stateToMove);
 
                 // Make sure that the toRemove has the newest state also
                 toRemove.put(posToMove, stateToMove);
@@ -227,7 +235,7 @@ public class BasicStructureRunner implements StructureRunner {
     public void taskDoDestroyNeighborUpdates() {
         affectedIndex = 0;
         // Rearrange block states so that they are in the correct order & use latest state :smartjang:
-        if (PistonLibConfig.tntDupingFix) {
+        if (PistonLibConfig.pistonPushingCacheFix) {
             int size = toDestroy.size();
             for (int i = toMove.size() - 1; i >= 0; i--) {
                 affectedStates[size++] = statesToMove.get(i);

--- a/src/main/java/ca/fxco/pistonlib/pistonLogic/structureRunners/DecoupledStructureRunner.java
+++ b/src/main/java/ca/fxco/pistonlib/pistonLogic/structureRunners/DecoupledStructureRunner.java
@@ -37,8 +37,8 @@ public class DecoupledStructureRunner implements StructureRunner {
     }
 
     @Override
-    public void taskPreventTntDuping() {
-        structureRunner.taskPreventTntDuping();
+    public void taskFixUpdatesAndStates() {
+        structureRunner.taskFixUpdatesAndStates();
     }
 
     @Override

--- a/src/main/java/ca/fxco/pistonlib/pistonLogic/structureRunners/MergingStructureRunner.java
+++ b/src/main/java/ca/fxco/pistonlib/pistonLogic/structureRunners/MergingStructureRunner.java
@@ -69,23 +69,22 @@ public class MergingStructureRunner extends BasicStructureRunner {
     public void taskMoveBlocks() {
         int moveSize = toMove.size();
         if (moveSize > 0) {
-            StructureGroup structureGroup = null;
-            if (moveSize > 1) { // Only use Structure group if there are more than 1 block entities in the group
-                structureGroup = StructureGroup.create(level);
-            }
-            for (int i = moveSize - 1; i >= 0; i--) {
-                BlockPos posToMove = toMove.get(i);
-                BlockPos dstPos = posToMove.relative(moveDir);
-                BlockState stateToMove = statesToMove.get(i);
-                BlockEntity blockEntityToMove = blockEntitiesToMove.get(i);
+            if (structure instanceof MergingPistonStructureResolver mergingStructure) {
+                List<BlockPos> toUnMerge = mergingStructure.getToUnMerge();
+                unMergingStates = new BlockState[toUnMerge.size()];
+                StructureGroup structureGroup = null;
+                if (moveSize > 1) { // Only use Structure group if there are more than 1 block entities in the group
+                    structureGroup = StructureGroup.create(level);
+                }
+                for (int i = moveSize - 1; i >= 0; i--) {
+                    BlockPos posToMove = toMove.get(i);
+                    BlockPos dstPos = posToMove.relative(moveDir);
+                    BlockState stateToMove = statesToMove.get(i);
+                    BlockEntity blockEntityToMove = blockEntitiesToMove.get(i);
 
-                boolean move = true;
+                    boolean move = true;
 
-                // UnMerge blocks
-                if (structure instanceof MergingPistonStructureResolver mergingStructure) {
-                    List<BlockPos> toUnMerge = mergingStructure.getToUnMerge();
-                    unMergingStates = new BlockState[toUnMerge.size()];
-
+                    // UnMerge blocks
                     if (toUnMerge.contains(posToMove) && stateToMove instanceof BlockStateBaseMerging bsbm) {
                         Pair<BlockState, BlockState> unmergedStates = null;
                         if (bsbm.getBlockEntityMergeRules().checkUnMerge() &&
@@ -108,20 +107,20 @@ public class MergingStructureRunner extends BasicStructureRunner {
                             move = false;
                         }
                     }
-                }
 
-                toRemove.remove(dstPos);
+                    toRemove.remove(dstPos);
 
-                BlockState movingBlock = this.family.getMoving().defaultBlockState()
-                        .setValue(BasicMovingBlock.FACING, facing);
-                BlockEntity movingBlockEntity = this.family
-                        .newMovingBlockEntity(structureGroup, dstPos, movingBlock, stateToMove, blockEntityToMove, facing, extend, false);
+                    BlockState movingBlock = this.family.getMoving().defaultBlockState()
+                            .setValue(BasicMovingBlock.FACING, facing);
+                    BlockEntity movingBlockEntity = this.family
+                            .newMovingBlockEntity(structureGroup, dstPos, movingBlock, stateToMove, blockEntityToMove, facing, extend, false);
 
-                level.setBlock(dstPos, movingBlock, UPDATE_MOVE_BY_PISTON | UPDATE_INVISIBLE);
-                level.setBlockEntity(movingBlockEntity);
+                    level.setBlock(dstPos, movingBlock, UPDATE_MOVE_BY_PISTON | UPDATE_INVISIBLE);
+                    level.setBlockEntity(movingBlockEntity);
 
-                if (move) {
-                    affectedStates[affectedIndex++] = stateToMove;
+                    if (move) {
+                        affectedStates[affectedIndex++] = stateToMove;
+                    }
                 }
             }
         }

--- a/src/main/java/ca/fxco/pistonlib/pistonLogic/structureRunners/StructureRunner.java
+++ b/src/main/java/ca/fxco/pistonlib/pistonLogic/structureRunners/StructureRunner.java
@@ -1,7 +1,5 @@
 package ca.fxco.pistonlib.pistonLogic.structureRunners;
 
-import ca.fxco.pistonlib.PistonLibConfig;
-
 public interface StructureRunner {
 
     void taskRemovePistonHeadOnRetract();
@@ -15,7 +13,7 @@ public interface StructureRunner {
 
     void taskDestroyBlocks();
 
-    void taskPreventTntDuping();
+    void taskFixUpdatesAndStates();
 
     void taskMoveBlocks();
 
@@ -49,9 +47,8 @@ public interface StructureRunner {
         // destroy blocks
         taskDestroyBlocks();
 
-        if (PistonLibConfig.tntDupingFix) {
-            taskPreventTntDuping();
-        }
+        // Fix cached states being used and updates
+        taskFixUpdatesAndStates();
 
         // move blocks
         taskMoveBlocks();


### PR DESCRIPTION
Split `tntDupingFix` into `tntDupingFix` & `pistonPushingCacheFix`
The new cache implementation will be on by default. It fixes countless dupes and bugs within the piston code. However, you can still use tnt duping with it enabled!
The tnt duping fix will be disabled by default. Some designs may no longer work, however that trade-off was done for stability sake. You can however always just disable `pistonPushingCacheFix` and get vanilla behavior...