### PR TITLE
Fix: half blocks

### DIFF
--- a/src/main/java/ca/fxco/pistonlib/helpers/HalfBlockUtils.java
+++ b/src/main/java/ca/fxco/pistonlib/helpers/HalfBlockUtils.java
@@ -28,12 +28,12 @@ public class HalfBlockUtils {
             Direction dir = dirs[i];
 
             maps[i] = Util.make(new HashMap<>(), map -> {
-                map.put(Utils.applyFacing(Direction.UP, dir), StickyType.STICKY);
-                map.put(Utils.applyFacing(Direction.DOWN, dir), StickyType.DEFAULT);
-                map.put(Utils.applyFacing(Direction.NORTH, dir), StickyType.CONDITIONAL);
-                map.put(Utils.applyFacing(Direction.SOUTH, dir), StickyType.CONDITIONAL);
-                map.put(Utils.applyFacing(Direction.EAST, dir), StickyType.CONDITIONAL);
+                map.put(Utils.applyFacing(Direction.NORTH, dir), StickyType.STICKY);
+                map.put(Utils.applyFacing(Direction.SOUTH, dir), StickyType.DEFAULT);
+                map.put(Utils.applyFacing(Direction.UP, dir), StickyType.CONDITIONAL);
+                map.put(Utils.applyFacing(Direction.DOWN, dir), StickyType.CONDITIONAL);
                 map.put(Utils.applyFacing(Direction.WEST, dir), StickyType.CONDITIONAL);
+                map.put(Utils.applyFacing(Direction.EAST, dir), StickyType.CONDITIONAL);
             });
         }
 

--- a/src/main/java/ca/fxco/pistonlib/pistonLogic/structureResolvers/MergingPistonStructureResolver.java
+++ b/src/main/java/ca/fxco/pistonlib/pistonLogic/structureResolvers/MergingPistonStructureResolver.java
@@ -44,10 +44,10 @@ public class MergingPistonStructureResolver extends BasicStructureResolver {
         return false;
     }
 
-    protected boolean cantMove(BlockPos pos, Direction dir) {
+    protected boolean attemptMoveLine(BlockPos pos, Direction dir) {
         BlockState state = this.level.getBlockState(pos);
         if (state.isAir() ||
-                pos.equals(this.pistonPos) ||
+                isPiston(pos) ||
                 this.toPush.contains(pos) ||
                 this.toMerge.contains(pos) ||
                 this.ignore.contains(pos)) {
@@ -89,11 +89,12 @@ public class MergingPistonStructureResolver extends BasicStructureResolver {
             state = this.level.getBlockState(blockPos);
 
             if (state.isAir() ||
-                    !canAdjacentBlockStick(pushDirOpposite, lastState, state) ||
-                    blockPos.equals(this.pistonPos) ||
+                    isPiston(blockPos) ||
+                    !canMoveAdjacentBlock(pushDirOpposite, lastState, state) ||
                     this.toMerge.contains(blockPos) ||
                     this.ignore.contains(blockPos) ||
-                    !this.controller.canMoveBlock(state, this.level, blockPos, this.pushDirection, false, pushDirOpposite)) {
+                    !this.controller.canMoveBlock(state, this.level, blockPos,
+                            this.pushDirection, false, pushDirOpposite)) {
                 break;
             }
             weight += state.pl$getWeight();
@@ -136,7 +137,7 @@ public class MergingPistonStructureResolver extends BasicStructureResolver {
                 for(int m = 0; m <= lastIndex + distance; ++m) {
                     BlockPos pos3 = this.toPush.get(m);
                     state = this.level.getBlockState(pos3);
-                    if (!attemptMove(state, pos3)) {
+                    if (attemptCreateBranchesAtBlock(state, pos3)) {
                         return true;
                     }
                 }
@@ -190,7 +191,8 @@ public class MergingPistonStructureResolver extends BasicStructureResolver {
                 return false;
             } else if (currentPos.equals(this.pistonPos)) {
                 return true;
-            } else if (!controller.canMoveBlock(state, this.level, currentPos, this.pushDirection, true, this.pushDirection)) {
+            } else if (!controller.canMoveBlock(state, this.level, currentPos,
+                    this.pushDirection, true, this.pushDirection)) {
                 return true;
             }
             if (state.pl$usesConfigurablePistonBehavior()) {


### PR DESCRIPTION
Fixes half blocks being sticky on the wrong side.
![image](https://github.com/user-attachments/assets/220192b2-3ce5-47a1-8e66-1a6505f9d403)

Also does a cleanup of the resolver.

All tested using gametest #47 
